### PR TITLE
enh: skip verbose plots when feature count exceeds limit

### DIFF
--- a/plsdo/cli.py
+++ b/plsdo/cli.py
@@ -113,6 +113,21 @@ def pls_main(argv=None):
             "THRESHOLD (default: 1.96). Does not affect CSV outputs."
         ),
     )
+    from plsdo.plotting import VERBOSE_FEATURE_LIMIT
+
+    run_parser.add_argument(
+        "--verbose-feature-limit",
+        default=None,
+        type=int,
+        help=(
+            f"Maximum features for verbose plots (default: "
+            f"{VERBOSE_FEATURE_LIMIT}). Above this limit, only the scree "
+            f"plot is produced — heatmaps and distribution plots become "
+            f"unreadable and extremely slow at high feature counts. "
+            f"Raising this value will incrementally degrade the quality "
+            f"and utility of the figures."
+        ),
+    )
 
     # --- plsdo cross-validate ---
     cv_parser = subparsers.add_parser(
@@ -231,6 +246,7 @@ def _dispatch_run(args):
         dpi=args.dpi,
         all_plots=args.all_plots,
         bsr_threshold=args.bsr_threshold,
+        verbose_feature_limit=args.verbose_feature_limit,
     )
 
 

--- a/plsdo/pipeline.py
+++ b/plsdo/pipeline.py
@@ -22,6 +22,7 @@ from plsdo.io import (
     zscore_columns,
 )
 from plsdo.plotting import (
+    VERBOSE_FEATURE_LIMIT,
     meta_colours,
     plot_bootstrap_heatmap,
     plot_heatmap,
@@ -74,6 +75,7 @@ def run_pipeline(
     dpi: int = 300,
     all_plots: bool = False,
     bsr_threshold: float = 1.96,
+    verbose_feature_limit: int | None = None,
 ) -> None:
     """Run a full PLS analysis pipeline.
 
@@ -113,6 +115,9 @@ def run_pipeline(
         Plot loading bars only for features with |bootstrap ratio|
         exceeding this threshold. Default 1.96 (≈ 95% CI under the
         standard-normal approximation). CSV outputs are unaffected.
+    verbose_feature_limit : int, optional
+        Maximum number of features before verbose plots (except scree)
+        are skipped. Defaults to ``VERBOSE_FEATURE_LIMIT`` (100).
     """
     # --- Set up output directory ---
     figures_dir = output_dir / "figures"
@@ -350,6 +355,7 @@ def run_pipeline(
             figures_dir=figures_dir,
             ext=ext,
             dpi=dpi,
+            verbose_feature_limit=verbose_feature_limit,
         )
 
     # --- Write log ---
@@ -614,9 +620,37 @@ def _plot_verbose(
     figures_dir: Path,
     ext: str,
     dpi: int,
+    verbose_feature_limit: int | None = None,
 ) -> None:
     """Generate additional diagnostic plots when --all-plots is requested."""
     n_components = len(model.s)
+
+    # --- Guard: skip feature-heavy plots when feature count is too high ---
+    limit = (
+        verbose_feature_limit
+        if verbose_feature_limit is not None
+        else VERBOSE_FEATURE_LIMIT
+    )
+    n_x = len(x_feature_names)
+    n_y = len(y_feature_names)
+    if max(n_x, n_y) > limit:
+        logger.warning(
+            "Skipping verbose plots (except scree): %d features exceeds "
+            "the %d-feature limit. These plots are unreadable at this "
+            "scale. Use the standard plots or extract data from the CSV "
+            "outputs for custom visualisation. To override, pass "
+            "--verbose-feature-limit N.",
+            max(n_x, n_y),
+            limit,
+        )
+        # Scree is fine at any scale — only depends on number of LVs
+        plot_scree(
+            s=model.s,
+            p_values=model.p_values,
+            out_path=figures_dir / f"scree.{ext}",
+            dpi=dpi,
+        )
+        return
 
     # Scree plot — all LVs
     plot_scree(

--- a/plsdo/plotting.py
+++ b/plsdo/plotting.py
@@ -14,6 +14,9 @@ logger = logging.getLogger("plsdo")
 # Threshold above which heatmap annotations are suppressed
 ANNOTATION_THRESHOLD = 30
 
+# Maximum number of features before verbose plots are skipped
+VERBOSE_FEATURE_LIMIT = 100
+
 
 def figure_size(
     n_rows: int,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,126 @@
+"""Tests for pipeline helpers."""
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from plsdo.pipeline import _plot_verbose
+from plsdo.plotting import VERBOSE_FEATURE_LIMIT
+
+
+def _make_mock_model(n_x: int, n_y: int, n_components: int = 2):
+    """Build a minimal mock PLS model with the attributes _plot_verbose needs."""
+    rng = np.random.default_rng(0)
+    return SimpleNamespace(
+        s=np.ones(n_components),
+        p_values=np.full(n_components, 0.01),
+        u=rng.standard_normal((n_x, n_components)),
+        vt=rng.standard_normal((n_components, n_y)),
+        u_bootstrap_ratios=rng.standard_normal((n_x, n_components)),
+        vt_bootstrap_ratios=rng.standard_normal((n_components, n_y)),
+    )
+
+
+class TestVerboseFeatureLimit:
+    """Verbose plot guard: skip feature-heavy plots above the limit."""
+
+    @pytest.fixture()
+    def figures_dir(self, tmp_path):
+        d = tmp_path / "figures"
+        d.mkdir()
+        return d
+
+    def test_guard_fires_at_default_limit(self, figures_dir, caplog):
+        """101 features exceeds the default 100 — only scree produced."""
+        n_features = VERBOSE_FEATURE_LIMIT + 1
+        model = _make_mock_model(n_x=n_features, n_y=n_features)
+
+        with caplog.at_level(logging.WARNING, logger="plsdo"):
+            _plot_verbose(
+                model=model,
+                method="correlational",
+                X=np.zeros((10, n_features)),
+                Y=np.zeros((10, n_features)),
+                x_feature_names=[f"x{i}" for i in range(n_features)],
+                y_feature_names=[f"y{i}" for i in range(n_features)],
+                x_colours=None,
+                y_colours=None,
+                final_lv_indices=np.array([0]),
+                final_lv_names=["LV1"],
+                config=None,
+                demo_aligned=None,
+                figures_dir=figures_dir,
+                ext="svg",
+                dpi=72,
+            )
+
+        # Guard warning was logged
+        assert any("Skipping verbose plots" in msg for msg in caplog.messages)
+
+        # Only scree was produced — no heatmaps or distributions
+        produced = sorted(p.name for p in figures_dir.iterdir())
+        assert produced == ["scree.svg"]
+
+    def test_explicit_override_bypasses_guard(self, figures_dir, caplog):
+        """150 features with limit=200 — guard does NOT fire."""
+        n_features = 150
+        model = _make_mock_model(n_x=n_features, n_y=n_features)
+
+        with caplog.at_level(logging.WARNING, logger="plsdo"):
+            _plot_verbose(
+                model=model,
+                method="correlational",
+                X=np.zeros((10, n_features)),
+                Y=np.zeros((10, n_features)),
+                x_feature_names=[f"x{i}" for i in range(n_features)],
+                y_feature_names=[f"y{i}" for i in range(n_features)],
+                x_colours=None,
+                y_colours=None,
+                final_lv_indices=np.array([0]),
+                final_lv_names=["LV1"],
+                config=None,
+                demo_aligned=None,
+                figures_dir=figures_dir,
+                ext="svg",
+                dpi=72,
+                verbose_feature_limit=200,
+            )
+
+        # No guard warning
+        assert not any("Skipping verbose plots" in msg for msg in caplog.messages)
+
+        # More than just scree was produced
+        produced = sorted(p.name for p in figures_dir.iterdir())
+        assert len(produced) > 1
+        assert "scree.svg" in produced
+
+    def test_explicit_lower_limit_fires_guard(self, figures_dir, caplog):
+        """60 features with limit=50 — guard fires."""
+        n_features = 60
+        model = _make_mock_model(n_x=n_features, n_y=n_features)
+
+        with caplog.at_level(logging.WARNING, logger="plsdo"):
+            _plot_verbose(
+                model=model,
+                method="correlational",
+                X=np.zeros((10, n_features)),
+                Y=np.zeros((10, n_features)),
+                x_feature_names=[f"x{i}" for i in range(n_features)],
+                y_feature_names=[f"y{i}" for i in range(n_features)],
+                x_colours=None,
+                y_colours=None,
+                final_lv_indices=np.array([0]),
+                final_lv_names=["LV1"],
+                config=None,
+                demo_aligned=None,
+                figures_dir=figures_dir,
+                ext="svg",
+                dpi=72,
+                verbose_feature_limit=50,
+            )
+
+        assert any("Skipping verbose plots" in msg for msg in caplog.messages)
+        produced = sorted(p.name for p in figures_dir.iterdir())
+        assert produced == ["scree.svg"]


### PR DESCRIPTION
## Summary

- Adds a guard to `_plot_verbose()` that skips heatmaps and distribution plots (but keeps scree) when the feature count exceeds a configurable limit (default: 100)
- Adds `--verbose-feature-limit` CLI flag so users can raise or lower the threshold
- Running `--all-plots` with large feature matrices (e.g. 550 features) previously caused the process to hang — these plots are also unreadable at that scale

## Test plan

- [x] Three new tests in `tests/test_pipeline.py` cover the guard logic (default fires, explicit override bypasses, explicit lower limit triggers)
- [x] Full test suite passes (109/109)
- [x] `plsdo run --help` shows the new flag with degradation warning