### PR TITLE
fix: single-source the package version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Run ruff
         run: ruff check plsdo/ tests/
+
+      - name: Check version consistency
+        run: python scripts/check_version.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run ruff
         run: uv run ruff check plsdo/ tests/
 
+      - name: Check version consistency
+        run: python scripts/check_version.py
+
   build:
     name: Build distribution
     needs: [test, lint]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,14 @@ Practical consequences: prefer stdlib over third-party where reasonable (argpars
 
 The `plsdo` name is claimed on PyPI. Releases are automated via `.github/workflows/release.yml` and triggered by pushing a version tag.
 
+The version is single-sourced: `pyproject.toml` reads it dynamically from `plsdo/__init__.py` via `[tool.hatch.version]`. `CITATION.cff` carries an independent copy, kept in step by `scripts/check_version.py` (run in CI).
+
 **Steps:**
-1. Bump `version` in `pyproject.toml` and `CITATION.cff` (keep `date-released` in sync).
-2. Commit: `chore: bump version to vX.Y.Z`
-3. Tag and push: `git tag vX.Y.Z && git push origin main --tags`
-4. The release workflow runs tests, builds, publishes to PyPI, and creates a GitHub release automatically.
+1. Bump `__version__` in `plsdo/__init__.py` and `version` in `CITATION.cff` (keep `date-released` in sync). Do **not** edit `pyproject.toml` — it derives the version automatically.
+2. Run `python scripts/check_version.py` to confirm the two agree.
+3. Commit: `chore: bump version to vX.Y.Z`
+4. Tag and push: `git tag vX.Y.Z && git push origin main --tags`
+5. The release workflow runs tests, builds, publishes to PyPI, and creates a GitHub release automatically.
 
 **Before first stable release:**
 - Update `README.md` and `docs/usage.md` installation instructions from `git clone` to `pip install plsdo`.

--- a/plsdo/__init__.py
+++ b/plsdo/__init__.py
@@ -1,3 +1,3 @@
 """PLS covariance analysis with statistical testing and visualisation."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plsdo"
-version = "0.1.1"
+dynamic = ["version"]
 description = "PLS covariance analysis with statistical testing and visualisation"
 readme = "README.md"
 keywords = ["PLS", "multivariate", "statistics", "analysis"]
@@ -52,6 +52,9 @@ Issues = "https://github.com/braincentrekcl/plsdo/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "plsdo/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -22,6 +22,17 @@ def _extract(path: Path, pattern: str) -> str:
     return match.group(1)
 
 
+def compare(package_version: str, citation_version: str) -> str | None:
+    """Return an error message if the two versions disagree, else None."""
+    if package_version != citation_version:
+        return (
+            f"Version mismatch: plsdo/__init__.py is {package_version!r} but "
+            f"CITATION.cff is {citation_version!r}. Update both (and "
+            f"CITATION.cff's date-released) before releasing."
+        )
+    return None
+
+
 def main() -> None:
     package_version = _extract(
         ROOT / "plsdo" / "__init__.py", r'__version__\s*=\s*"([^"]+)"'
@@ -30,12 +41,9 @@ def main() -> None:
         ROOT / "CITATION.cff", r'^version:\s*"?([^"\n]+)"?',
     )
 
-    if package_version != citation_version:
-        sys.exit(
-            f"Version mismatch: plsdo/__init__.py is {package_version!r} but "
-            f"CITATION.cff is {citation_version!r}. Update both (and "
-            f"CITATION.cff's date-released) before releasing."
-        )
+    error = compare(package_version, citation_version)
+    if error:
+        sys.exit(error)
 
     print(f"Versions agree: {package_version}")
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Fail if the package version and CITATION.cff version disagree.
+
+The canonical version lives in ``plsdo/__init__.py`` (read dynamically by
+hatchling). ``CITATION.cff`` carries an independent copy for citation
+metadata. This guard keeps the two in step — run it in CI and before
+cutting a release.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _extract(path: Path, pattern: str) -> str:
+    text = path.read_text()
+    match = re.search(pattern, text, re.MULTILINE)
+    if match is None:
+        sys.exit(f"Could not find a version in {path}")
+    return match.group(1)
+
+
+def main() -> None:
+    package_version = _extract(
+        ROOT / "plsdo" / "__init__.py", r'__version__\s*=\s*"([^"]+)"'
+    )
+    citation_version = _extract(
+        ROOT / "CITATION.cff", r'^version:\s*"?([^"\n]+)"?',
+    )
+
+    if package_version != citation_version:
+        sys.exit(
+            f"Version mismatch: plsdo/__init__.py is {package_version!r} but "
+            f"CITATION.cff is {citation_version!r}. Update both (and "
+            f"CITATION.cff's date-released) before releasing."
+        )
+
+    print(f"Versions agree: {package_version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -1,0 +1,43 @@
+"""Tests for the version-drift guard in scripts/check_version.py.
+
+The script is not an importable package, so load it by path.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_version.py"
+_spec = importlib.util.spec_from_file_location("check_version", _SCRIPT)
+check_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_version)
+
+
+class TestExtract:
+    def test_finds_version(self, tmp_path):
+        f = tmp_path / "init.py"
+        f.write_text('__version__ = "1.2.3"\n')
+        assert check_version._extract(f, r'__version__\s*=\s*"([^"]+)"') == "1.2.3"
+
+    def test_finds_multiline_anchored_version(self, tmp_path):
+        # The ^version: anchor must not match cff-version: on an earlier line.
+        f = tmp_path / "CITATION.cff"
+        f.write_text('cff-version: 1.2.0\nversion: "0.4.0"\n')
+        assert check_version._extract(f, r'^version:\s*"?([^"\n]+)"?') == "0.4.0"
+
+    def test_missing_version_exits(self, tmp_path):
+        f = tmp_path / "init.py"
+        f.write_text("# no version here\n")
+        with pytest.raises(SystemExit):
+            check_version._extract(f, r'__version__\s*=\s*"([^"]+)"')
+
+
+class TestCompare:
+    def test_agree_returns_none(self):
+        assert check_version.compare("0.1.1", "0.1.1") is None
+
+    def test_mismatch_returns_message(self):
+        msg = check_version.compare("0.1.1", "9.9.9")
+        assert msg is not None
+        assert "0.1.1" in msg and "9.9.9" in msg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from plsdo.cli import pls_main
 
@@ -227,14 +229,19 @@ class TestLogContents:
 
 
 def test_version_flag(capsys):
+    # Tests the CLI wiring, not the version *value* (which check_version.py owns):
+    # --version must exit 0 and emit "plsdo <real version>", catching a hardcoded
+    # or empty version string without going stale on a literal.
     from plsdo import __version__
 
     with pytest.raises(SystemExit) as exc_info:
         pls_main(["--version"])
     assert exc_info.value.code == 0
-    captured = capsys.readouterr()
-    assert "plsdo" in captured.out
-    assert __version__ in captured.out
+    out = capsys.readouterr().out.strip()
+    # Reports the package version (catches a hardcoded/decoupled version)...
+    assert out == f"plsdo {__version__}"
+    # ...and that version is well-formed (guard on the CLI output, not the import).
+    assert re.match(r"^plsdo \d+\.\d+", out)
 
 
 class TestCrossValidate:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,12 +227,14 @@ class TestLogContents:
 
 
 def test_version_flag(capsys):
+    from plsdo import __version__
+
     with pytest.raises(SystemExit) as exc_info:
         pls_main(["--version"])
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "plsdo" in captured.out
-    assert "0.1.0" in captured.out
+    assert __version__ in captured.out
 
 
 class TestCrossValidate:


### PR DESCRIPTION
## What

The package version was duplicated and had drifted: `pyproject.toml` and `CITATION.cff` said `0.1.1`, but `plsdo/__init__.py` still said `0.1.0`. Since `__init__.py` is what `plsdo.__version__` and the `log.txt` run stamp report, the installed package advertised the **wrong version**.

## Changes

- **Single-source the version.** `pyproject.toml` now reads the version dynamically from `plsdo/__init__.py` via `[tool.hatch.version]` (`dynamic = ["version"]`), and `__init__.py` is corrected to `0.1.1`. One canonical source.
- **Guard against `CITATION.cff` drift.** New stdlib-only `scripts/check_version.py` fails if `plsdo/__init__.py` and `CITATION.cff` disagree, run as a step in the `lint` CI job (and usable locally at release time).
- **De-stale the version test.** `test_version_flag` now asserts the CLI `--version` output against `plsdo.__version__` rather than a hardcoded literal, so it can't go stale again.
- **Docs.** Updated the "Cutting a release" steps in `CLAUDE.md` for the new single source.

## Verification

- `plsdo.__version__` → `0.1.1`
- `uv build` produces `plsdo-0.1.1` artifacts
- `python scripts/check_version.py` → "Versions agree: 0.1.1"; exits 1 on a forced mismatch
- Full suite: 127 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)