### PR TITLE
Goal 3: restructure CLI to subcommand-per-method + release scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** the CLI now uses one subcommand per method.
+  `plsdo run --method correlational` and `plsdo run --method discriminatory`
+  are replaced by `plsdo correlational` and `plsdo discriminatory`, with
+  `corr` and `discrim` as short aliases. Each subcommand exposes only its
+  relevant flags — `--x` is required by `correlational` and absent from
+  `discriminatory` — so invalid combinations are rejected structurally rather
+  than at runtime.
+- Flag and subcommand-name abbreviations are no longer accepted
+  (`allow_abbrev=False`), so saved invocations cannot silently break when a
+  future flag makes a prefix ambiguous.
+- The version is single-sourced from `plsdo/__init__.py` via hatchling's
+  dynamic version; `pyproject.toml` no longer carries a separate number.
+
+### Added
+
+- Test coverage reporting (`pytest-cov`) with a 95% floor, enforced in CI.
+- A CI guard that fails if `CITATION.cff` and the package version drift apart.
+- End-to-end tests covering the full pipeline and cross-validation output.
+- This changelog and a `CONTRIBUTING.md`.
+
+### Fixed
+
+- `plsdo.__version__` was hardcoded to `0.1.0` while the package was `0.1.1`;
+  the version is now correct and single-sourced.
+
+## [0.1.1] - 2026-05-22
+
+### Fixed
+
+- Box-and-strip plots assigned colours in the wrong order; switched to a
+  `FacetGrid` + `boxplot` construction so box and strip colours match.
+
+### Added
+
+- Zenodo DOI in the README and `CITATION.cff`.
+
+## [0.1.0] - 2026-05-21
+
+Initial release: correlational and discriminatory PLS via a single SVD engine,
+permutation testing, bootstrap resampling with Procrustes alignment, two-stage
+latent-variable filtering, cross-validation, a command-line interface, and a
+suite of diagnostic plots.
+
+[Unreleased]: https://github.com/braincentrekcl/plsdo/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/braincentrekcl/plsdo/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/braincentrekcl/plsdo/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The package has a strict separation of concerns across five modules:
 
 **LV filtering is two-stage.** `filter_lvs()` keeps LVs that are (1) significant by permutation (p < 0.05) and (2) have at least one feature with |bootstrap ratio| > 1.96 on *both* the X and Y sides. Result is a boolean `final_lvs` mask.
 
-**CV flips X and Y.** `cross_validate.py` uses Y (continuous data) as the predictor and dummy-coded groups as the target, so `pls.predict()` gives predicted group scores. This is the opposite convention from `plsdo run`.
+**CV flips X and Y.** `cross_validate.py` uses Y (continuous data) as the predictor and dummy-coded groups as the target, so `pls.predict()` gives predicted group scores. This is the opposite convention from `plsdo discriminatory`.
 
 ## Design philosophy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to plsdo
+
+Thanks for your interest in improving `plsdo`. This guide covers the
+development setup and the conventions the project follows.
+
+## Development setup
+
+`plsdo` uses [uv](https://docs.astral.sh/uv/) for environment and dependency
+management.
+
+```bash
+# Create and activate a virtual environment
+uv venv .venv && source .venv/bin/activate
+
+# Install the package with development dependencies
+uv pip install -e ".[dev]"
+```
+
+The `dev` extra includes the test runner, coverage, and the linter. Cross-
+validation additionally requires the `cv` extra (`uv pip install -e ".[dev,cv]"`).
+
+## Running tests
+
+```bash
+# Run the whole suite
+.venv/bin/pytest tests/
+
+# Run a single file or test
+.venv/bin/pytest tests/test_core.py
+.venv/bin/pytest tests/test_core.py::TestBootstrap::test_seed_reproducibility
+
+# Run with coverage (a 95% floor is enforced in CI)
+.venv/bin/pytest tests/ --cov=plsdo
+```
+
+Each new function should have at least one positive test (correct input →
+correct output) and one negative test (invalid input → informative error).
+
+## Linting and formatting
+
+The project uses [ruff](https://docs.astral.sh/ruff/) for both:
+
+```bash
+.venv/bin/ruff check .
+.venv/bin/ruff format .
+```
+
+CI runs the linter, the formatter check, and the test suite on Python
+3.10–3.12. Please make sure all three pass before opening a pull request.
+
+## Conventions
+
+- **British English** in all prose: documentation, commit messages,
+  user-facing strings, and comments.
+- **Type hints** on all function signatures.
+- **Commit messages** use a conventional prefix and a single-line subject:
+  `feat`, `fix`, `enh`, `ref`, `test`, `docs`, `chore`. Make small, logically
+  coherent commits rather than one large batch.
+- **No data in the package.** Test data lives in `tests/data/` and is synthetic
+  and small.
+- Note any user-facing change in `CHANGELOG.md` under the `Unreleased` heading.
+
+## Scope
+
+`plsdo` deliberately stays lean: it implements PLS and its associated
+reliability machinery (permutation testing, bootstrap ratios), not a general
+statistics toolkit. New dependencies and new inference procedures beyond PLS
+itself need a clear justification. When in doubt, open an issue to discuss
+before implementing.
+
+## Reporting issues
+
+Use the issue templates under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE) for bug reports, feature
+requests, and documentation issues.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv pip install -e ".[dev]"
 ### Correlational PLS
 
 ```bash
-plsdo run --method c \
+plsdo correlational \
   --x brain_measures.csv \
   --y behaviour_scores.csv \
   --demographics participants.csv \
@@ -58,13 +58,16 @@ plsdo run --method c \
 ### Discriminatory PLS
 
 ```bash
-plsdo run --method d \
+plsdo discriminatory \
   --y mri_features.csv \
   --demographics participants.csv \
   --group-col drug_group \
   --subject-id participant_id \
   --output results/
 ```
+
+`corr` and `discrim` are accepted as short aliases for `correlational`
+and `discriminatory`.
 
 ### Cross-validation (discriminatory only)
 

--- a/docs/interpreting-output.md
+++ b/docs/interpreting-output.md
@@ -69,7 +69,8 @@ The permutation test of CV accuracy answers: is the observed accuracy
 significantly better than chance? A p-value below 0.05 indicates that
 the model generalises beyond the training data.
 
-**Important:** do not select the number of components based on `plsdo run`
-results and then feed that into cross-validation. This introduces
+**Important:** do not select the number of components based on
+`plsdo discriminatory` results and then feed that into cross-validation.
+This introduces
 circularity. Use all components (the default) or use nested
 cross-validation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,7 @@ uv pip install -e ".[dev]"
 Finds covariance patterns between two continuous data matrices:
 
 ```bash
-plsdo run --method c \
+plsdo correlational \
   --x brain_measures.csv \
   --y behaviour_scores.csv \
   --demographics participants.csv \
@@ -42,13 +42,16 @@ plsdo run --method c \
 Finds patterns that discriminate between groups:
 
 ```bash
-plsdo run --method d \
+plsdo discriminatory \
   --y mri_features.csv \
   --demographics participants.csv \
   --group-col drug_group \
   --subject-id participant_id \
   --output results/
 ```
+
+`corr` and `discrim` are accepted as short aliases for `correlational`
+and `discriminatory` (e.g. `plsdo corr ...`).
 
 ### Cross-Validation
 
@@ -84,7 +87,8 @@ groups:
 ```
 
 Then use `--groups groups.yaml` instead of `--group-col`.
-This works for both `plsdo run` and `plsdo cross-validate`; for
+This works for `plsdo correlational`, `plsdo discriminatory`, and
+`plsdo cross-validate`; for
 cross-validation the column with `role: x_axis` is used as the
 classification target.
 
@@ -142,4 +146,5 @@ at higher dimensions — but the figures will degrade in quality.
 
 ## All Options
 
-Run `plsdo run --help` or `plsdo cross-validate --help` for the full list.
+Run `plsdo correlational --help`, `plsdo discriminatory --help`, or
+`plsdo cross-validate --help` for the full list.

--- a/plsdo/cli.py
+++ b/plsdo/cli.py
@@ -142,6 +142,10 @@ def pls_main(argv=None):
         help="Cross-validate discriminatory PLS model",
         parents=[common],
         allow_abbrev=False,
+        epilog=(
+            "For --groups, the column with role: x_axis is used as the "
+            "classification target."
+        ),
     )
     cv_parser.add_argument(
         "--n-folds", default=5, type=int, help="Number of CV folds (default: 5)"

--- a/plsdo/cli.py
+++ b/plsdo/cli.py
@@ -6,14 +6,6 @@ import sys
 from pathlib import Path
 
 
-METHOD_ALIASES = {
-    "c": "correlational",
-    "correlational": "correlational",
-    "d": "discriminatory",
-    "discriminatory": "discriminatory",
-}
-
-
 def _error(message: str) -> None:
     """Print error message to stderr and exit with code 2."""
     print(f"error: {message}", file=sys.stderr)
@@ -27,7 +19,10 @@ def pls_main(argv=None):
         argv: Command-line arguments. None uses sys.argv (normal CLI usage);
               pass a list for testing.
     """
-    # Shared flags available on every subcommand
+    from plsdo import __version__
+    from plsdo.plotting import VERBOSE_FEATURE_LIMIT
+
+    # Flags shared by every subcommand.
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(
         "--verbose",
@@ -36,75 +31,52 @@ def pls_main(argv=None):
         default=False,
         help="Enable verbose logging output",
     )
-
-    parser = argparse.ArgumentParser(
-        prog="plsdo",
-        description="PLS covariance analysis with statistical testing and visualisation.",
-    )
-    from plsdo import __version__
-
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"%(prog)s {__version__}",
-    )
-    subparsers = parser.add_subparsers(dest="command")
-
-    # --- plsdo run ---
-    run_parser = subparsers.add_parser("run", help="Run PLS analysis", parents=[common])
-    run_parser.add_argument(
-        "--method", "-m", required=True, help="correlational/c or discriminatory/d"
-    )
-    run_parser.add_argument(
-        "--x",
-        dest="x_path",
-        default=None,
-        help="X matrix CSV (required for correlational)",
-    )
-    run_parser.add_argument("--y", dest="y_path", required=True, help="Y matrix CSV")
-    run_parser.add_argument("--demographics", required=True, help="Demographics CSV")
-    run_parser.add_argument("--output", required=True, help="Output directory")
-    run_parser.add_argument(
+    common.add_argument("--y", dest="y_path", required=True, help="Y matrix CSV")
+    common.add_argument("--demographics", required=True, help="Demographics CSV")
+    common.add_argument("--output", required=True, help="Output directory")
+    common.add_argument("--subject-id", default=None, help="Subject ID column name")
+    group = common.add_mutually_exclusive_group()
+    group.add_argument(
         "--group-col", default=None, help="Group column name (shorthand for YAML)"
     )
-    run_parser.add_argument(
+    group.add_argument(
         "--groups", dest="groups_path", default=None, help="Groups YAML config file"
     )
-    run_parser.add_argument("--subject-id", default=None, help="Subject ID column name")
-    run_parser.add_argument("--x-meta", default=None, help="X metadata CSV")
-    run_parser.add_argument("--y-meta", default=None, help="Y metadata CSV")
-    run_parser.add_argument(
-        "--n-perms",
-        default=10000,
-        type=int,
-        help="Number of permutations (default: 10000)",
-    )
-    run_parser.add_argument(
-        "--n-bootstraps",
-        default=10000,
-        type=int,
-        help="Number of bootstrap resamples (default: 10000)",
-    )
-    run_parser.add_argument(
+    common.add_argument(
         "--seed", default=42, type=int, help="Random seed (default: 42)"
     )
-    run_parser.add_argument(
-        "--all-plots",
-        action="store_true",
-        default=False,
-        help="Generate all plots including diagnostics",
-    )
-    run_parser.add_argument(
+    common.add_argument(
         "--format",
         dest="img_format",
         default="svg",
         choices=["svg", "png"],
         help="Image format (default: svg)",
     )
-    run_parser.add_argument(
-        "--dpi", default=300, type=int, help="Image DPI (default: 300)"
+    common.add_argument("--dpi", default=300, type=int, help="Image DPI (default: 300)")
+    common.add_argument(
+        "--all-plots",
+        action="store_true",
+        default=False,
+        help="Generate all plots including diagnostics",
     )
-    run_parser.add_argument(
+
+    # Flags shared by the two PLS-fitting subcommands (not cross-validate).
+    run_common = argparse.ArgumentParser(add_help=False, parents=[common])
+    run_common.add_argument("--x-meta", default=None, help="X metadata CSV")
+    run_common.add_argument("--y-meta", default=None, help="Y metadata CSV")
+    run_common.add_argument(
+        "--n-perms",
+        default=10000,
+        type=int,
+        help="Number of permutations (default: 10000)",
+    )
+    run_common.add_argument(
+        "--n-bootstraps",
+        default=10000,
+        type=int,
+        help="Number of bootstrap resamples (default: 10000)",
+    )
+    run_common.add_argument(
         "--bsr-threshold",
         default=1.96,
         type=float,
@@ -113,9 +85,7 @@ def pls_main(argv=None):
             "THRESHOLD (default: 1.96). Does not affect CSV outputs."
         ),
     )
-    from plsdo.plotting import VERBOSE_FEATURE_LIMIT
-
-    run_parser.add_argument(
+    run_common.add_argument(
         "--verbose-feature-limit",
         default=None,
         type=int,
@@ -129,25 +99,50 @@ def pls_main(argv=None):
         ),
     )
 
+    # allow_abbrev=False: a CLI bound for a stable release should not silently
+    # resolve abbreviated flags or subcommand names — that breaks saved scripts
+    # the moment a new flag makes a prefix ambiguous. Set per-parser (not
+    # inherited from parents); the explicit corr/discrim aliases are unaffected.
+    parser = argparse.ArgumentParser(
+        prog="plsdo",
+        description="PLS covariance analysis with statistical testing and visualisation.",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # --- plsdo correlational / corr ---
+    corr_parser = subparsers.add_parser(
+        "correlational",
+        aliases=["corr"],
+        help="Correlational PLS between two continuous matrices",
+        parents=[run_common],
+        allow_abbrev=False,
+    )
+    corr_parser.add_argument("--x", dest="x_path", required=True, help="X matrix CSV")
+    corr_parser.set_defaults(method="correlational", func=_dispatch_run)
+
+    # --- plsdo discriminatory / discrim ---
+    discrim_parser = subparsers.add_parser(
+        "discriminatory",
+        aliases=["discrim"],
+        help="Discriminatory PLS between groups (X built from --group-col/--groups)",
+        parents=[run_common],
+        allow_abbrev=False,
+    )
+    discrim_parser.set_defaults(method="discriminatory", func=_dispatch_run)
+
     # --- plsdo cross-validate ---
     cv_parser = subparsers.add_parser(
         "cross-validate",
         help="Cross-validate discriminatory PLS model",
         parents=[common],
+        allow_abbrev=False,
     )
-    cv_parser.add_argument("--y", dest="y_path", required=True, help="Y matrix CSV")
-    cv_parser.add_argument("--demographics", required=True, help="Demographics CSV")
-    cv_parser.add_argument("--output", required=True, help="Output directory")
-    cv_parser.add_argument(
-        "--group-col", default=None, help="Group column name (shorthand for YAML)"
-    )
-    cv_parser.add_argument(
-        "--groups",
-        dest="groups_path",
-        default=None,
-        help="Groups YAML config file (CV target is the x_axis column)",
-    )
-    cv_parser.add_argument("--subject-id", default=None, help="Subject ID column name")
     cv_parser.add_argument(
         "--n-folds", default=5, type=int, help="Number of CV folds (default: 5)"
     )
@@ -166,25 +161,7 @@ def pls_main(argv=None):
         type=int,
         help="Number of permutations for CV test (default: 1000)",
     )
-    cv_parser.add_argument(
-        "--seed", default=42, type=int, help="Random seed (default: 42)"
-    )
-    cv_parser.add_argument(
-        "--all-plots",
-        action="store_true",
-        default=False,
-        help="Generate all plots including diagnostics",
-    )
-    cv_parser.add_argument(
-        "--format",
-        dest="img_format",
-        default="svg",
-        choices=["svg", "png"],
-        help="Image format (default: svg)",
-    )
-    cv_parser.add_argument(
-        "--dpi", default=300, type=int, help="Image DPI (default: 300)"
-    )
+    cv_parser.set_defaults(func=_dispatch_cross_validate)
 
     args = parser.parse_args(argv)
 
@@ -193,47 +170,32 @@ def pls_main(argv=None):
         format="%(levelname)s: %(message)s",
     )
 
-    if args.command is None:
+    if not hasattr(args, "func"):
         parser.print_help()
         sys.exit(1)
-    elif args.command == "run":
-        _dispatch_run(args)
-    elif args.command == "cross-validate":
-        _dispatch_cross_validate(args)
+    args.func(args)
 
 
 def _dispatch_run(args):
     """Validate run arguments and dispatch to pipeline."""
     from plsdo.pipeline import run_pipeline
 
-    # --- Resolve method ---
-    method_lower = args.method.lower()
-    if method_lower not in METHOD_ALIASES:
-        _error(
-            f"Unknown method '{args.method}'. Use correlational/c or discriminatory/d."
-        )
-    method = METHOD_ALIASES[method_lower]
-
-    # --- Validate method-specific constraints ---
-    if method == "correlational" and args.x_path is None:
-        _error("Correlational PLS requires --x.")
-    if method == "discriminatory" and args.x_path is not None:
-        _error("Discriminatory PLS builds X from --group-col. Do not provide --x.")
     if (
-        method == "discriminatory"
+        args.method == "discriminatory"
         and args.group_col is None
         and args.groups_path is None
     ):
         _error("Discriminatory PLS requires --group-col or --groups.")
-    if args.group_col is not None and args.groups_path is not None:
-        _error("--group-col and --groups are mutually exclusive.")
+
+    # --x exists only on the correlational subparser; absent for discriminatory.
+    x_path = getattr(args, "x_path", None)
 
     run_pipeline(
-        method=method,
+        method=args.method,
         y_path=Path(args.y_path),
         demographics_path=Path(args.demographics),
         output_dir=Path(args.output),
-        x_path=Path(args.x_path) if args.x_path else None,
+        x_path=Path(x_path) if x_path else None,
         group_col=args.group_col,
         groups_path=Path(args.groups_path) if args.groups_path else None,
         subject_id=args.subject_id,
@@ -256,8 +218,6 @@ def _dispatch_cross_validate(args):
 
     if args.group_col is None and args.groups_path is None:
         _error("Cross-validate requires --group-col or --groups.")
-    if args.group_col is not None and args.groups_path is not None:
-        _error("--group-col and --groups are mutually exclusive.")
 
     cross_validate_pipeline(
         y_path=Path(args.y_path),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ class TestRunValidation:
         with pytest.raises(SystemExit) as exc_info:
             pls_main([])
         assert exc_info.value.code != 0
+        assert "usage: plsdo" in capsys.readouterr().out
 
     def test_correlational_without_x_errors(self, data_dir, tmp_path, capsys):
         with pytest.raises(SystemExit) as exc_info:
@@ -337,7 +338,7 @@ class TestCrossValidate:
         assert "group_col: group" in log
         assert "groups:" in log
 
-    def test_group_col_and_groups_mutually_exclusive(self, data_dir, tmp_path):
+    def test_group_col_and_groups_mutually_exclusive(self, data_dir, tmp_path, capsys):
         with pytest.raises(SystemExit) as exc_info:
             pls_main(
                 [
@@ -355,6 +356,9 @@ class TestCrossValidate:
                 ]
             )
         assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        # argparse enforces the mutual exclusion structurally (matches the run side).
+        assert "not allowed with" in captured.err.lower()
 
     def test_all_plots_creates_convergence_figure(self, data_dir, tmp_path):
         out = tmp_path / "cv_allplots"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,28 +5,16 @@ from plsdo.cli import pls_main
 
 
 class TestRunValidation:
-    def test_method_required(self, data_dir):
+    def test_no_subcommand_prints_help_and_exits(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
-            pls_main(
-                [
-                    "run",
-                    "--y",
-                    str(data_dir / "behaviour.csv"),
-                    "--demographics",
-                    str(data_dir / "demographics.csv"),
-                    "--output",
-                    "/tmp/pls_test",
-                ]
-            )
+            pls_main([])
         assert exc_info.value.code != 0
 
-    def test_method_c_without_x_errors(self, data_dir, tmp_path, capsys):
+    def test_correlational_without_x_errors(self, data_dir, tmp_path, capsys):
         with pytest.raises(SystemExit) as exc_info:
             pls_main(
                 [
-                    "run",
-                    "--method",
-                    "c",
+                    "correlational",
                     "--y",
                     str(data_dir / "behaviour.csv"),
                     "--demographics",
@@ -37,15 +25,14 @@ class TestRunValidation:
             )
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
-        assert "correlational pls requires --x" in captured.err.lower()
+        # --x is structurally required on the correlational parser.
+        assert "--x" in captured.err.lower()
 
-    def test_method_d_with_x_errors(self, data_dir, tmp_path, capsys):
+    def test_discriminatory_with_x_errors(self, data_dir, tmp_path, capsys):
         with pytest.raises(SystemExit) as exc_info:
             pls_main(
                 [
-                    "run",
-                    "--method",
-                    "d",
+                    "discriminatory",
                     "--x",
                     str(data_dir / "brain.csv"),
                     "--y",
@@ -60,15 +47,14 @@ class TestRunValidation:
             )
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
-        assert "do not provide --x" in captured.err.lower()
+        # The discriminatory parser has no --x; argparse rejects it.
+        assert "unrecognized arguments" in captured.err.lower()
 
-    def test_method_d_without_group_col_errors(self, data_dir, tmp_path, capsys):
+    def test_discriminatory_without_group_col_errors(self, data_dir, tmp_path, capsys):
         with pytest.raises(SystemExit) as exc_info:
             pls_main(
                 [
-                    "run",
-                    "--method",
-                    "d",
+                    "discriminatory",
                     "--y",
                     str(data_dir / "behaviour.csv"),
                     "--demographics",
@@ -81,12 +67,10 @@ class TestRunValidation:
         captured = capsys.readouterr()
         assert "requires --group-col" in captured.err.lower()
 
-    def test_method_accepts_case_insensitive(self, data_dir, tmp_path):
+    def test_corr_alias_runs(self, data_dir, tmp_path):
         pls_main(
             [
-                "run",
-                "--method",
-                "Correlational",
+                "corr",
                 "--x",
                 str(data_dir / "brain.csv"),
                 "--y",
@@ -105,6 +89,29 @@ class TestRunValidation:
         )
         assert (tmp_path / "out" / "data").exists()
 
+    def test_discrim_alias_runs(self, data_dir, tmp_path):
+        out = tmp_path / "out_discrim"
+        pls_main(
+            [
+                "discrim",
+                "--y",
+                str(data_dir / "behaviour.csv"),
+                "--demographics",
+                str(data_dir / "demographics.csv"),
+                "--group-col",
+                "group",
+                "--subject-id",
+                "subject_id",
+                "--output",
+                str(out),
+                "--n-perms",
+                "10",
+                "--n-bootstraps",
+                "10",
+            ]
+        )
+        assert (out / "data").exists()
+
     def test_group_col_and_groups_mutually_exclusive(
         self,
         data_dir,
@@ -114,9 +121,7 @@ class TestRunValidation:
         with pytest.raises(SystemExit) as exc_info:
             pls_main(
                 [
-                    "run",
-                    "--method",
-                    "c",
+                    "correlational",
                     "--x",
                     str(data_dir / "brain.csv"),
                     "--y",
@@ -133,15 +138,38 @@ class TestRunValidation:
             )
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
-        assert "mutually exclusive" in captured.err.lower()
+        # argparse enforces the mutual exclusion structurally.
+        assert "not allowed with" in captured.err.lower()
+
+    def test_abbreviated_flags_are_rejected(self, data_dir, tmp_path, capsys):
+        # allow_abbrev=False: --n-perm must not silently resolve to --n-perms, so
+        # saved scripts cannot break when a future flag makes a prefix ambiguous.
+        # All required flags are supplied so the only error is the abbreviation.
+        with pytest.raises(SystemExit) as exc_info:
+            pls_main(
+                [
+                    "discriminatory",
+                    "--y",
+                    str(data_dir / "behaviour.csv"),
+                    "--demographics",
+                    str(data_dir / "demographics.csv"),
+                    "--group-col",
+                    "group",
+                    "--output",
+                    str(tmp_path / "out"),
+                    "--n-perm",
+                    "10",
+                ]
+            )
+        assert exc_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "unrecognized arguments" in captured.err.lower()
 
     def test_all_plots_creates_verbose_figures(self, data_dir, tmp_path):
         out = tmp_path / "out_allplots"
         pls_main(
             [
-                "run",
-                "--method",
-                "d",
+                "discriminatory",
                 "--y",
                 str(data_dir / "behaviour.csv"),
                 "--demographics",
@@ -170,9 +198,7 @@ class TestLogContents:
         out = tmp_path / "out_log"
         pls_main(
             [
-                "run",
-                "--method",
-                "c",
+                "correlational",
                 "--x",
                 str(data_dir / "brain.csv"),
                 "--y",
@@ -203,9 +229,7 @@ class TestLogContents:
         out = tmp_path / "out_log_none"
         pls_main(
             [
-                "run",
-                "--method",
-                "c",
+                "correlational",
                 "--x",
                 str(data_dir / "brain.csv"),
                 "--y",


### PR DESCRIPTION
## Goal 3 — CLI restructure + release scaffolding

Restructures the CLI to one subcommand per method and adds the missing release
connective tissue, while the API is still explicitly alpha (the breaking change
lands now, not after any freeze).

### Breaking change — CLI surface

- `plsdo run --method correlational|discriminatory` → **`plsdo correlational`** and
  **`plsdo discriminatory`** sibling subcommands, alongside the existing
  `plsdo cross-validate`.
- Short aliases: **`corr`** and **`discrim`**.
- Method-specific argument rules are now **structural**, not runtime-checked: the
  `correlational` parser requires `--x`; the `discriminatory` parser omits it entirely.
  The `--group-col`/`--groups` mutual exclusion is an argparse
  `add_mutually_exclusive_group()`. This deletes the manual `_error` branches and the
  `METHOD_ALIASES` table, and makes `--help` self-documenting per subcommand.
- **`allow_abbrev=False`** on every parser: flag and subcommand-name abbreviations are no
  longer silently resolved, so a saved invocation can't break when a future flag makes a
  prefix ambiguous. The explicit `corr`/`discrim` aliases are unaffected (they're registered
  names, not abbreviations). This is a deliberate robustness choice for a CLI bound for a
  stable release.

Shared flags are factored into a `common` parent parser, with a `run_common` parent layering
the fit-only flags (`--n-perms`, `--bsr-threshold`, …) on top for the two PLS subcommands.

### Forward compatibility

The subcommand model is what makes a future `plsdo sparse` a clean additive **1.1.0** — a new
sibling parser touching nothing existing — rather than swelling a single `run` command's flag
union.

### Release scaffolding

- **`CHANGELOG.md`** (Keep a Changelog), backfilling 0.1.0 → 0.1.1 and recording the breaking
  CLI change under `Unreleased`.
- **`CONTRIBUTING.md`** (dev setup, test/lint commands, commit-prefix and British-English
  conventions).
- `.github/ISSUE_TEMPLATE/` was already populated, so no change there.

### Docs

`README.md` and `docs/` updated to the new invocation, including the aliases.

### Verification

- `pytest tests/` — 164 passed.
- `ruff check plsdo/ tests/` — clean (CI's gate).
- New/updated `test_cli.py` covers: subcommand dispatch, both aliases, structural `--x`
  rules, argparse-native mutual exclusion, the discriminatory group requirement, and a
  regression test that abbreviated flags are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
