### PR TITLE
enh: add cv alias for cross-validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `cv` as a short alias for the `cross-validate` subcommand.
 - Test coverage reporting (`pytest-cov`) with a 95% floor, enforced in CI.
 - A CI guard that fails if `CITATION.cff` and the package version drift apart.
 - End-to-end tests covering the full pipeline and cross-validation output.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ plsdo discriminatory \
 ```
 
 `corr` and `discrim` are accepted as short aliases for `correlational`
-and `discriminatory`.
+and `discriminatory`, and `cv` for `cross-validate`.
 
 ### Cross-validation (discriminatory only)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,7 +51,8 @@ plsdo discriminatory \
 ```
 
 `corr` and `discrim` are accepted as short aliases for `correlational`
-and `discriminatory` (e.g. `plsdo corr ...`).
+and `discriminatory` (e.g. `plsdo corr ...`), and `cv` for
+`cross-validate`.
 
 ### Cross-Validation
 

--- a/plsdo/cli.py
+++ b/plsdo/cli.py
@@ -139,6 +139,7 @@ def pls_main(argv=None):
     # --- plsdo cross-validate ---
     cv_parser = subparsers.add_parser(
         "cross-validate",
+        aliases=["cv"],
         help="Cross-validate discriminatory PLS model",
         parents=[common],
         allow_abbrev=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -312,6 +312,31 @@ class TestCrossValidate:
         assert (out / "data").exists()
         assert (out / "log.txt").exists()
 
+    def test_cv_alias_runs(self, data_dir, tmp_path):
+        out = tmp_path / "cv_alias"
+        pls_main(
+            [
+                "cv",
+                "--y",
+                str(data_dir / "behaviour.csv"),
+                "--demographics",
+                str(data_dir / "demographics.csv"),
+                "--group-col",
+                "group",
+                "--subject-id",
+                "subject_id",
+                "--output",
+                str(out),
+                "--n-folds",
+                "3",
+                "--n-repeats",
+                "2",
+                "--n-permutations",
+                "10",
+            ]
+        )
+        assert (out / "data").exists()
+
     def test_accepts_groups_yaml(self, data_dir, tmp_path):
         out = tmp_path / "cv_yaml"
         pls_main(


### PR DESCRIPTION
Adds `cv` as a short alias for the `cross-validate` subcommand, matching the `corr`/`discrim` aliases introduced for the PLS-fitting subcommands in #18. Pre-1.0 CLI polish — cheap to settle before any surface freeze.

- `subparsers.add_parser("cross-validate", aliases=["cv"], ...)`
- Test `test_cv_alias_runs` (written first; verified it failed with `invalid choice: 'cv'` before the alias was added)
- README, `docs/usage.md`, and CHANGELOG note the alias

All CLI tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)