### PR TITLE
chore: enforce ruff format via pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,13 @@ jobs:
         run: pip install uv
 
       - name: Install ruff
-        run: uv pip install --system ruff
+        run: uv pip install --system ruff==0.15.11
 
-      - name: Run ruff
+      - name: Run ruff check
         run: ruff check plsdo/ tests/
+
+      - name: Run ruff format check
+        run: ruff format --check plsdo/ tests/
 
       - name: Check version consistency
         run: python scripts/check_version.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
       - name: Install uv
         run: pip install uv
 
-      - name: Install ruff
-        run: uv pip install --system ruff==0.15.11
+      - name: Install package and dev dependencies
+        run: uv pip install --system -e ".[dev]"
 
       - name: Run ruff check
-        run: ruff check plsdo/ tests/
+        run: ruff check plsdo/ tests/ scripts/
 
       - name: Run ruff format check
-        run: ruff format --check plsdo/ tests/
+        run: ruff format --check plsdo/ tests/ scripts/
 
       - name: Check version consistency
         run: python scripts/check_version.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,11 @@ jobs:
           uv venv
           uv pip install -e ".[dev]"
 
-      - name: Run ruff
-        run: uv run ruff check plsdo/ tests/
+      - name: Run ruff check
+        run: uv run ruff check plsdo/ tests/ scripts/
+
+      - name: Run ruff format check
+        run: uv run ruff format --check plsdo/ tests/ scripts/
 
       - name: Check version consistency
         run: python scripts/check_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Run `pre-commit install` once to enable these hooks locally.
-# The ruff version here is pinned to match the CI lint job; bump both together.
+# Keep this rev in step with the ruff pin in pyproject.toml; bump both together.
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Run `pre-commit install` once to enable these hooks locally.
+# The ruff version here is pinned to match the CI lint job; bump both together.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,15 @@ uv venv .venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
 ```
 
-The `dev` extra includes the test runner, coverage, and the linter. Cross-
-validation additionally requires the `cv` extra (`uv pip install -e ".[dev,cv]"`).
+The `dev` extra includes the test runner, coverage, the linter, and
+`pre-commit`. Cross-validation additionally requires the `cv` extra
+(`uv pip install -e ".[dev,cv]"`).
+
+Install the git hooks once so ruff runs automatically on every commit:
+
+```bash
+pre-commit install
+```
 
 ## Running tests
 

--- a/plsdo/core.py
+++ b/plsdo/core.py
@@ -109,9 +109,7 @@ class PLS:
             perm_s_list.append(perm_s)
 
         self.permuted_singular_values = np.stack(perm_s_list, axis=1)
-        self.p_values = corrected_pvalue(
-            self.s, self.permuted_singular_values, axis=1
-        )
+        self.p_values = corrected_pvalue(self.s, self.permuted_singular_values, axis=1)
         self.significant_lvs = self.p_values < 0.05
         self._permuted = True
 

--- a/plsdo/cross_validate.py
+++ b/plsdo/cross_validate.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+
 try:
     from sklearn.cross_decomposition import PLSRegression
     from sklearn.metrics import (

--- a/plsdo/io.py
+++ b/plsdo/io.py
@@ -167,9 +167,7 @@ def align_subjects(
         col = sid[0]
         id_sets = [set(df[col]) for df in dfs]
     else:
-        id_sets = [
-            set(df[sid].itertuples(index=False, name=None)) for df in dfs
-        ]
+        id_sets = [set(df[sid].itertuples(index=False, name=None)) for df in dfs]
 
     shared_ids = id_sets[0]
     for s in id_sets[1:]:
@@ -203,8 +201,7 @@ def align_subjects(
         ordered_df = pd.DataFrame(ordered_tuples, columns=sid)
 
     aligned = [
-        ordered_df.merge(df, on=sid, how="left").reset_index(drop=True)
-        for df in dfs
+        ordered_df.merge(df, on=sid, how="left").reset_index(drop=True) for df in dfs
     ]
     return aligned
 
@@ -345,9 +342,7 @@ class GroupConfig:
     groups: list[GroupSpec] = field(default_factory=list)
 
     @classmethod
-    def from_group_col(
-        cls, group_col: str, subject_id: SubjectID | None = None
-    ):
+    def from_group_col(cls, group_col: str, subject_id: SubjectID | None = None):
         """Create a config from a single --group-col string."""
         return cls(
             subject_id=subject_id,
@@ -368,9 +363,7 @@ class GroupConfig:
 
     def hue_column(self) -> Optional[str]:
         """Column name of the group with role 'hue', or None if none."""
-        return next(
-            (g.column for g in self.active_groups() if g.role == "hue"), None
-        )
+        return next((g.column for g in self.active_groups() if g.role == "hue"), None)
 
     def facet_rows_column(self) -> Optional[str]:
         """Column name of the group with role 'facet_rows', or None if none."""

--- a/plsdo/pipeline.py
+++ b/plsdo/pipeline.py
@@ -200,7 +200,7 @@ def run_pipeline(
         if len(active) == 1:
             prefix = active[0].column + "_"
             x_display_names = [
-                name[len(prefix):] if name.startswith(prefix) else name
+                name[len(prefix) :] if name.startswith(prefix) else name
                 for name in x_feature_names
             ]
         else:

--- a/plsdo/plotting.py
+++ b/plsdo/plotting.py
@@ -133,11 +133,15 @@ def plot_heatmap(
         fmt=".2f" if annotate else "",
     )
     ax.set_xticklabels(
-        ax.get_xticklabels(), rotation=45, ha="right",
+        ax.get_xticklabels(),
+        rotation=45,
+        ha="right",
         fontsize=tick_fontsize,
     )
     ax.set_yticklabels(
-        ax.get_yticklabels(), rotation=0, fontsize=tick_fontsize,
+        ax.get_yticklabels(),
+        rotation=0,
+        fontsize=tick_fontsize,
     )
     if subtitle:
         fig.suptitle(subtitle)
@@ -195,9 +199,7 @@ def _heatmap_with_colour_bars(
     ax.set_xticklabels(
         ax.get_xticklabels(), rotation=45, ha="right", fontsize=tick_fontsize
     )
-    ax.set_yticklabels(
-        ax.get_yticklabels(), rotation=0, fontsize=tick_fontsize
-    )
+    ax.set_yticklabels(ax.get_yticklabels(), rotation=0, fontsize=tick_fontsize)
     if subtitle:
         g.figure.suptitle(subtitle)
     g.savefig(out_path, transparent=False, dpi=dpi)
@@ -352,16 +354,24 @@ def _box_strip_facet(
     g = sns.FacetGrid(data=data, col=col, sharex=False, **grid_kwargs)
     g.map_dataframe(
         sns.boxplot,
-        x=x, y=y, hue=hue,
-        order=order, hue_order=hue_order,
-        palette=palette, dodge=box_dodge,
+        x=x,
+        y=y,
+        hue=hue,
+        order=order,
+        hue_order=hue_order,
+        palette=palette,
+        dodge=box_dodge,
         **_BOXPLOT_STYLE,
     )
     g.map_dataframe(
         sns.stripplot,
-        x=x, y=y, hue=hue,
-        order=order, hue_order=hue_order,
-        palette=palette, dodge=strip_dodge,
+        x=x,
+        y=y,
+        hue=hue,
+        order=order,
+        hue_order=hue_order,
+        palette=palette,
+        dodge=strip_dodge,
         **_STRIPPLOT_STYLE,
     )
     if rotate_xticklabels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ cv = [
 dev = [
     "pytest",
     "pytest-cov",
-    "ruff",
+    "ruff==0.15.11",
+    "pre-commit",
     "scikit-learn",
 ]
 

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -38,7 +38,8 @@ def main() -> None:
         ROOT / "plsdo" / "__init__.py", r'__version__\s*=\s*"([^"]+)"'
     )
     citation_version = _extract(
-        ROOT / "CITATION.cff", r'^version:\s*"?([^"\n]+)"?',
+        ROOT / "CITATION.cff",
+        r'^version:\s*"?([^"\n]+)"?',
     )
 
     error = compare(package_version, citation_version)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -74,6 +74,7 @@ class TestPLSFit:
             col = model.u_loadings[:, i]
             assert col[np.argmax(np.abs(col))] > 0
 
+
 class TestPermutationTest:
     def _fitted_model(self, x_array, y_array):
         from plsdo.io import zscore_columns
@@ -197,6 +198,7 @@ class TestBootstrap:
         m2.bootstrap(n_bootstraps=100)
 
         np.testing.assert_array_equal(m1.u_bootstrap_ratios, m2.u_bootstrap_ratios)
+
 
 class TestBootstrapZscoreX:
     def test_zscore_x_false_does_not_alter_dummy_x(self):

--- a/tests/test_cross_validate.py
+++ b/tests/test_cross_validate.py
@@ -177,7 +177,11 @@ class TestSklearnImportGuard:
         import sys
 
         for mod in list(sys.modules):
-            if mod == "sklearn" or mod.startswith("sklearn.") or mod == "plsdo.cross_validate":
+            if (
+                mod == "sklearn"
+                or mod.startswith("sklearn.")
+                or mod == "plsdo.cross_validate"
+            ):
                 monkeypatch.delitem(sys.modules, mod, raising=False)
 
         real_import = builtins.__import__

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -211,12 +211,8 @@ class TestAlignSubjectsMultiColumn:
         assert "not present in all files" in caplog.text
 
     def test_multi_column_empty_intersection_raises(self):
-        df1 = pd.DataFrame(
-            {"sid": ["a", "a"], "run": [1, 2], "v1": [10, 20]}
-        )
-        df2 = pd.DataFrame(
-            {"sid": ["b", "b"], "run": [1, 2], "v2": [30, 40]}
-        )
+        df1 = pd.DataFrame({"sid": ["a", "a"], "run": [1, 2], "v1": [10, 20]})
+        df2 = pd.DataFrame({"sid": ["b", "b"], "run": [1, 2], "v2": [30, 40]})
         with pytest.raises(ValueError, match="No subjects shared"):
             align_subjects([df1, df2], subject_id=["sid", "run"])
 
@@ -224,9 +220,7 @@ class TestAlignSubjectsMultiColumn:
         df1 = pd.DataFrame({"id": ["a", "b", "c"], "v1": [1, 2, 3]})
         df2 = pd.DataFrame({"id": ["c", "a", "b"], "v2": [30, 10, 20]})
         aligned_str = align_subjects([df1.copy(), df2.copy()], subject_id="id")
-        aligned_list = align_subjects(
-            [df1.copy(), df2.copy()], subject_id=["id"]
-        )
+        aligned_list = align_subjects([df1.copy(), df2.copy()], subject_id=["id"])
         for a, b in zip(aligned_str, aligned_list):
             pd.testing.assert_frame_equal(a, b)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -111,6 +111,7 @@ class TestVerboseFeatureLimit:
         assert len(produced) > 1
         assert "scree.svg" in produced
 
+
 class TestMultiIndexSubjectScores:
     """Integration: compound subject ID produces a two-level index in CSV."""
 
@@ -471,9 +472,7 @@ class TestFacetWiring:
     def test_default_layout_threads_col_wrap(self, monkeypatch, tmp_path):
         """In the default layout (LV on columns, no facet) facet_col_wrap is
         passed through to control column wrapping."""
-        config = GroupConfig(
-            groups=[GroupSpec("group", "x_axis", facet_col_wrap=3)]
-        )
+        config = GroupConfig(groups=[GroupSpec("group", "x_axis", facet_col_wrap=3)])
         calls = self._capture_boxstrip_calls(config, monkeypatch, tmp_path)
         assert calls[0]["col_col"] == "LV"
         assert calls[0]["row_col"] is None

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -209,17 +209,21 @@ class TestPlotScoresBoxstrip:
         real_stripplot = sns.stripplot
 
         def spy_boxplot(*args, **kwargs):
-            captured["boxplot"].append({
-                "palette": kwargs.get("palette"),
-                "hue_order": kwargs.get("hue_order"),
-            })
+            captured["boxplot"].append(
+                {
+                    "palette": kwargs.get("palette"),
+                    "hue_order": kwargs.get("hue_order"),
+                }
+            )
             return real_boxplot(*args, **kwargs)
 
         def spy_stripplot(*args, **kwargs):
-            captured["stripplot"].append({
-                "palette": kwargs.get("palette"),
-                "hue_order": kwargs.get("hue_order"),
-            })
+            captured["stripplot"].append(
+                {
+                    "palette": kwargs.get("palette"),
+                    "hue_order": kwargs.get("hue_order"),
+                }
+            )
             return real_stripplot(*args, **kwargs)
 
         monkeypatch.setattr(plotting_mod.sns, "boxplot", spy_boxplot)
@@ -272,7 +276,9 @@ class TestPlotScoresBoxstrip:
                 rows.append({"group": g, "score": rng.standard_normal(), "LV": "LV1"})
         scores_df = pd.DataFrame(rows)
         scores_df["group"] = pd.Categorical(
-            scores_df["group"], categories=cat_order, ordered=True,
+            scores_df["group"],
+            categories=cat_order,
+            ordered=True,
         )
 
         # Prevent plt.close so we can inspect the rendered figure
@@ -306,9 +312,7 @@ class TestPlotScoresBoxstrip:
                 continue
             for offset, fc in zip(offsets, fcs):
                 x_pos = round(offset[0])
-                strip_colours.setdefault(x_pos, set()).add(
-                    tuple(fc[:3].round(4))
-                )
+                strip_colours.setdefault(x_pos, set()).add(tuple(fc[:3].round(4)))
 
         # Each box patch colour should match the strip colour at the
         # same position.
@@ -341,7 +345,9 @@ class TestPlotScoresBoxstrip:
                             }
                         )
         df = pd.DataFrame(rows)
-        df["group"] = pd.Categorical(df["group"], categories=["A", "B", "C"], ordered=True)
+        df["group"] = pd.Categorical(
+            df["group"], categories=["A", "B", "C"], ordered=True
+        )
         return df
 
     def test_row_col_produces_grid_rows(self, tmp_output, monkeypatch):


### PR DESCRIPTION
## What

Enforces ruff formatting, which had drifted (11 files were unformatted) and was unenforced anywhere.

- **CI**: pin `ruff==0.15.11` and add a `ruff format --check plsdo/ tests/` step to the lint job. Previously CI ran `ruff check` only — the formatter was never verified, despite CONTRIBUTING.md claiming it was.
- **pre-commit**: new `.pre-commit-config.yaml` running `ruff-check --fix` + `ruff-format`, pinned to the same `v0.15.11` so the hook and CI never disagree. Added `pre-commit` to the `dev` extra and documented `pre-commit install` in CONTRIBUTING.md.
- **`sty:` commit**: applies `ruff format` across `plsdo/`, `tests/`, and `scripts/` so the new check passes.

## Notes

- The ruff version is pinned in three places (pre-commit `rev`, dev extra, CI) deliberately, to keep them in lockstep. Bump all three together.
- CI's format check is scoped to `plsdo/ tests/` (matching the existing `ruff check` scope); the pre-commit hook covers `scripts/` locally.

## Verification

- `ruff format --check .` clean
- `ruff check plsdo/ tests/` passes
- `pytest tests/` — 208 passed