### PR TITLE
chore: bump GitHub Actions to Node.js 24 major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v6
         with:
@@ -35,7 +35,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v6
         with:
@@ -60,7 +60,7 @@ jobs:
     needs: [test, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v6
         with:
@@ -70,7 +70,7 @@ jobs:
         run: uv build
 
       - name: Upload distribution artefacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -84,7 +84,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -100,7 +100,7 @@ jobs:
       contents: write
     steps:
       - name: Download distribution artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
GitHub has deprecated the Node.js 20 action runtime: workflows are force-migrated to Node 24 on 2026-06-16, and Node 20 is removed entirely on 2026-09-16.

This bumps the first-party actions still pinned to Node 20 majors to their latest Node 24 majors:

- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8

All of these run on Node 24 and are drop-in for the existing simple usage. Exact-pinned third-party actions (`pypa/gh-action-pypi-publish`, `softprops/action-gh-release`, `astral-sh/setup-uv`) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)